### PR TITLE
Basic SwiftPM Integration

### DIFF
--- a/Fixtures/JSON-RPC/JSON/workspace-didChangeWatchedFiles-changed.json
+++ b/Fixtures/JSON-RPC/JSON/workspace-didChangeWatchedFiles-changed.json
@@ -1,0 +1,1 @@
+{"changes":[{"uri":"file:///Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug.yaml","type":2}]}

--- a/Fixtures/JSON-RPC/JSON/workspace-didChangeWatchedFiles-created.json
+++ b/Fixtures/JSON-RPC/JSON/workspace-didChangeWatchedFiles-created.json
@@ -1,0 +1,1 @@
+{"changes":[{"uri":"file:///Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release.yaml","type":1}]}

--- a/Fixtures/JSON-RPC/JSON/workspace-didChangeWatchedFiles-deleted.json
+++ b/Fixtures/JSON-RPC/JSON/workspace-didChangeWatchedFiles-deleted.json
@@ -1,0 +1,1 @@
+{"changes":[{"uri":"file:///Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug.yaml","type":3}]}

--- a/Fixtures/JSON-RPC/Requests/workspace-didChangeWatchedFiles-changed.txt
+++ b/Fixtures/JSON-RPC/Requests/workspace-didChangeWatchedFiles-changed.txt
@@ -1,0 +1,3 @@
+Content-Length: 192
+
+{"jsonrpc":"2.0","method":"workspace/didChangeWatchedFiles","params":{"changes":[{"uri":"file:///Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug.yaml","type":2}]}}

--- a/Fixtures/JSON-RPC/Requests/workspace-didChangeWatchedFiles-created.txt
+++ b/Fixtures/JSON-RPC/Requests/workspace-didChangeWatchedFiles-created.txt
@@ -1,0 +1,3 @@
+Content-Length: 194
+
+{"jsonrpc":"2.0","method":"workspace/didChangeWatchedFiles","params":{"changes":[{"uri":"file:///Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release.yaml","type":1}]}}

--- a/Fixtures/JSON-RPC/Requests/workspace-didChangeWatchedFiles-deleted.txt
+++ b/Fixtures/JSON-RPC/Requests/workspace-didChangeWatchedFiles-deleted.txt
@@ -1,0 +1,3 @@
+Content-Length: 192
+
+{"jsonrpc":"2.0","method":"workspace/didChangeWatchedFiles","params":{"changes":[{"uri":"file:///Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug.yaml","type":3}]}}

--- a/Fixtures/ValidLayouts/Simple/.build/debug.yaml
+++ b/Fixtures/ValidLayouts/Simple/.build/debug.yaml
@@ -1,0 +1,31 @@
+client:
+  name: swift-build
+tools: {}
+targets:
+  "test": ["/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple.build/bar.swift.o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple.build/main.swift.o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple.swiftmodule","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple"]
+  "main": ["/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple.build/bar.swift.o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple.build/main.swift.o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple.swiftmodule","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple"]
+default: "main"
+commands: 
+  "<Simple.module>":
+    tool: swift-compiler
+    executable: "/Users/ryan/Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2016-12-13-a.xctoolchain/usr/bin/swiftc"
+    module-name: "Simple"
+    module-output-path: "/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple.swiftmodule"
+    inputs: ["/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/Sources/bar.swift","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/Sources/main.swift"]
+    outputs: ["/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple.build/bar.swift.o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple.build/main.swift.o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple.swiftmodule"]
+    import-paths: ["/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug"]
+    temps-path: "/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple.build"
+    objects: ["/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple.build/bar.swift.o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple.build/main.swift.o"]
+    other-args: ["-j8","-D","SWIFT_PACKAGE","-Onone","-g","-enable-testing","-F","/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks","-target","x86_64-apple-macosx10.10","-sdk","/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk","-module-cache-path","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/ModuleCache"]
+    sources: ["/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/Sources/bar.swift","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/Sources/main.swift"]
+    is-library: false
+    enable-whole-module-optimization: false
+    num-threads: "8"
+
+  "<Simple.exe>":
+    tool: shell
+    description: "Linking ./.build/debug/Simple"
+    inputs: ["/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple.build/bar.swift.o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple.build/main.swift.o"]
+    outputs: ["/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple"]
+    args: ["/Users/ryan/Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2016-12-13-a.xctoolchain/usr/bin/swiftc","-target","x86_64-apple-macosx10.10","-sdk","/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk","-g","-L/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug","-o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple","-F","/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks","-emit-executable","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple.build/bar.swift.o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/debug/Simple.build/main.swift.o"]
+

--- a/Fixtures/ValidLayouts/Simple/.build/release.yaml
+++ b/Fixtures/ValidLayouts/Simple/.build/release.yaml
@@ -1,0 +1,31 @@
+client:
+  name: swift-build
+tools: {}
+targets:
+  "test": ["/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple.build/bar.swift.o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple.build/main.swift.o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple.swiftmodule","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple"]
+  "main": ["/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple.build/bar.swift.o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple.build/main.swift.o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple.swiftmodule","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple"]
+default: "main"
+commands: 
+  "<Simple.module>":
+    tool: swift-compiler
+    executable: "/Users/ryan/Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2016-12-13-a.xctoolchain/usr/bin/swiftc"
+    module-name: "Simple"
+    module-output-path: "/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple.swiftmodule"
+    inputs: ["/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/Sources/bar.swift","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/Sources/main.swift"]
+    outputs: ["/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple.build/bar.swift.o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple.build/main.swift.o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple.swiftmodule"]
+    import-paths: ["/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release"]
+    temps-path: "/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple.build"
+    objects: ["/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple.build/bar.swift.o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple.build/main.swift.o"]
+    other-args: ["-j8","-D","SWIFT_PACKAGE","-O","-F","/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks","-target","x86_64-apple-macosx10.10","-sdk","/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk","-module-cache-path","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/ModuleCache"]
+    sources: ["/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/Sources/bar.swift","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/Sources/main.swift"]
+    is-library: false
+    enable-whole-module-optimization: true
+    num-threads: "8"
+
+  "<Simple.exe>":
+    tool: shell
+    description: "Linking ./.build/release/Simple"
+    inputs: ["/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple.build/bar.swift.o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple.build/main.swift.o"]
+    outputs: ["/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple"]
+    args: ["/Users/ryan/Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2016-12-13-a.xctoolchain/usr/bin/swiftc","-target","x86_64-apple-macosx10.10","-sdk","/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk","-L/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release","-o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple","-F","/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks","-emit-executable","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple.build/bar.swift.o","/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple/.build/release/Simple.build/main.swift.o"]
+

--- a/Package.pins
+++ b/Package.pins
@@ -47,7 +47,7 @@
       "package": "SWXMLHash",
       "reason": null,
       "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
-      "version": "3.0.4"
+      "version": "3.0.3"
     },
     {
       "package": "SourceKit",
@@ -59,13 +59,13 @@
       "package": "SourceKitten",
       "reason": null,
       "repositoryURL": "https://github.com/RLovelett/SourceKitten.git",
-      "version": "0.18.0-beta.2"
+      "version": "0.18.0-beta.1"
     },
     {
       "package": "Yams",
       "reason": null,
       "repositoryURL": "https://github.com/jpsim/Yams.git",
-      "version": "0.2.0"
+      "version": "0.1.4"
     }
   ],
   "version": 1

--- a/Package.swift
+++ b/Package.swift
@@ -4,11 +4,13 @@ let package = Package(
     name: "langserver-swift",
     targets: [
         Target(name: "JSONRPC"),
-        Target(name: "LanguageServerProtocol", dependencies: ["JSONRPC"]),
+        Target(name: "YamlConvertable"),
+        Target(name: "LanguageServerProtocol", dependencies: ["YamlConvertable", "JSONRPC"]),
         Target(name: "LanguageServer", dependencies: ["LanguageServerProtocol", "JSONRPC"])
     ],
     dependencies: [
         .Package(url: "https://github.com/RLovelett/SourceKitten.git", majorVersion: 0),
+        .Package(url: "https://github.com/jpsim/Yams.git", Version(0, 1, 4)),
         .Package(url: "https://github.com/thoughtbot/Argo.git", majorVersion: 4),
         .Package(url: "https://github.com/edwardaux/Ogra.git", majorVersion: 4),
         .Package(url: "https://github.com/thoughtbot/Curry.git", majorVersion: 3)

--- a/Sources/LanguageServer/Functions/handle.swift
+++ b/Sources/LanguageServer/Functions/handle.swift
@@ -22,17 +22,21 @@ func handle(_ request: Request) -> Response {
             workspace = Workspace(parameters)
             let response = Response(to: request, is: InitializeResult(workspace.capabilities))
             return response
+        case "workspace/didChangeWatchedFiles":
+            let parameters: DidChangeWatchedFilesParams = try request.parse()
+            workspace.receive(notification: parameters)
+            return Response(to: request, is: JSON.null)
         case "textDocument/didChange":
-            let parameters: DidChangeTextDocumentParams = try request.parse()
-            try workspace.update(byClient: parameters)
+            let document: DidChangeTextDocumentParams = try request.parse()
+            try workspace.client(modified: document)
             return Response(to: request, is: JSON.null)
         case "textDocument/didClose":
-            let parameters: DidCloseTextDocumentParams = try request.parse()
-            workspace.close(byClient: parameters)
+            let document: DidCloseTextDocumentParams = try request.parse()
+            workspace.client(closed: document)
             return Response(to: request, is: JSON.null)
         case "textDocument/didOpen":
-            let parameters: DidOpenTextDocumentParams = try request.parse()
-            workspace.open(byClient: parameters)
+            let document: DidOpenTextDocumentParams = try request.parse()
+            workspace.client(opened: document)
             return Response(to: request, is: JSON.null)
 //        case "textDocument/didSave":
 //            fatalError("\(request.method) is not implemented yet.")

--- a/Sources/LanguageServerProtocol/Extenstions/Argo.swift
+++ b/Sources/LanguageServerProtocol/Extenstions/Argo.swift
@@ -14,17 +14,17 @@ extension Request {
 
     func decode<T: Decodable>() -> Decoded<T> where T.DecodedType == T {
         do {
-            let json: Any = try self.failableSend()
+            let json = try self.sendAndReceiveJSON()
             return T.decode(JSON(json))
         } catch {
             return .customError(error.localizedDescription)
         }
     }
 
-    func decode<T: Decodable>() -> Decoded<[T]> where T.DecodedType == T {
+    func decode<T: Decodable>(key: String = "key.results") -> Decoded<[T]> where T.DecodedType == T {
         do {
-            let json: Any = try self.failableSend()
-            let result: Decoded<[T]> = JSON(json) <|| "key.results"
+            let json = try self.sendAndReceiveJSON()
+            let result: Decoded<[T]> = JSON(json) <|| key
             return result
         } catch {
             return .customError(error.localizedDescription)

--- a/Sources/LanguageServerProtocol/Extenstions/URL.swift
+++ b/Sources/LanguageServerProtocol/Extenstions/URL.swift
@@ -19,6 +19,14 @@ extension URL {
         return !isDirectory
     }
 
+    /// Test if a `URL` is a child node of a parent.
+    ///
+    /// - Parameter child: The URL to test.
+    /// - Returns: True if the argument is a child of this instance.
+    func isParent(of child: URL) -> Bool {
+        return child.path.hasPrefix(self.path)
+    }
+
 }
 
 extension URL : TextDocumentIdentifier {

--- a/Sources/LanguageServerProtocol/Functions/CommonRoot.swift
+++ b/Sources/LanguageServerProtocol/Functions/CommonRoot.swift
@@ -1,0 +1,39 @@
+//
+//  CommonRoot.swift
+//  langserver-swift
+//
+//  Created by Ryan Lovelett on 12/24/16.
+//
+//
+
+import Foundation
+
+/// Extract the Swift module root directory.
+///
+/// The module root directory is the longest common path between two sources in the module. Or
+/// if there is only 1 source then its just the last directory.
+///
+/// ```
+/// let urls = [
+///   URL(fileURLWithPath: "/module/Sources/dir1/dir1.A/foo.swift", isDirectory: false),
+///   URL(fileURLWithPath: "/module/Sources/dir1/bar.swift", isDirectory: false)
+/// ]
+/// commonRoot(urls) // Returns /module/Sources/dir1/
+/// ```
+///
+/// - Precondition: The collection cannot be empty.
+///
+/// - Parameter sources: A collection of fully qualified paths to Swift sources in a module.
+/// - Returns: The root directory of the collection.
+func commonRoot<C: Collection>(_ sources: C) -> URL
+    where C.Iterator.Element == URL
+{
+    precondition(!sources.isEmpty, "A module must have at least 1 source.")
+    if sources.count == 1, let single = sources.first {
+        return single.deletingLastPathComponent()
+    } else {
+        let first = sources[sources.startIndex]
+        let second = sources[sources.index(after: sources.startIndex)]
+        return URL(fileURLWithPath: first.path.commonPrefix(with: second.path), isDirectory: true)
+    }
+}

--- a/Sources/LanguageServerProtocol/Types/DidChangeWatchedFilesParams.swift
+++ b/Sources/LanguageServerProtocol/Types/DidChangeWatchedFilesParams.swift
@@ -1,0 +1,26 @@
+//
+//  DidChangeWatchedFilesParams.swift
+//  langserver-swift
+//
+//  Created by Ryan Lovelett on 12/17/16.
+//
+//
+
+import Argo
+import Curry
+import Runes
+
+public struct DidChangeWatchedFilesParams {
+
+    /// The actual file events.
+    let changes: [FileEvent]
+
+}
+
+extension DidChangeWatchedFilesParams : Decodable {
+
+    public static func decode(_ json: JSON) -> Decoded<DidChangeWatchedFilesParams> {
+        return curry(DidChangeWatchedFilesParams.init(changes:)) <^> (json <|| "changes")
+    }
+
+}

--- a/Sources/LanguageServerProtocol/Types/FileChangeType.swift
+++ b/Sources/LanguageServerProtocol/Types/FileChangeType.swift
@@ -1,0 +1,25 @@
+//
+//  FileChangeType.swift
+//  langserver-swift
+//
+//  Created by Ryan Lovelett on 12/17/16.
+//
+//
+
+import Argo
+
+/// The file event type
+enum FileChangeType: Int {
+
+    /// The file got created.
+    case Created = 1
+
+    /// The file got changed.
+    case Changed = 2
+
+    /// The file got deleted.
+    case Deleted = 3
+
+}
+
+extension FileChangeType : Decodable { }

--- a/Sources/LanguageServerProtocol/Types/FileEvent.swift
+++ b/Sources/LanguageServerProtocol/Types/FileEvent.swift
@@ -1,0 +1,33 @@
+//
+//  FileEvent.swift
+//  langserver-swift
+//
+//  Created by Ryan Lovelett on 12/17/16.
+//
+//
+
+import Argo
+import Curry
+import Foundation
+import Runes
+
+/// An event describing a file change.
+struct FileEvent {
+
+    /// The file's URI
+    let uri: URL
+
+    /// The change type.
+    let type: FileChangeType
+
+}
+
+extension FileEvent : Decodable {
+
+    static func decode(_ json: JSON) -> Decoded<FileEvent> {
+        return curry(FileEvent.init)
+            <^> json <| "uri"
+            <*> json <| "type"
+    }
+
+}

--- a/Sources/LanguageServerProtocol/Types/SwiftModule.swift
+++ b/Sources/LanguageServerProtocol/Types/SwiftModule.swift
@@ -1,0 +1,118 @@
+//
+//  SwiftModule.swift
+//  langserver-swift
+//
+//  Created by Ryan Lovelett on 12/18/16.
+//
+//
+
+import Argo
+import Curry
+import Foundation
+import Runes
+import YamlConvertable
+import Yams
+
+/// A module, typically defined and managed by [SwiftPM](), that manages the sources and the compiler arguments
+/// that should be sent to SourceKit.
+struct SwiftModule {
+
+    /// The name of the Swift module.
+    let name: String
+
+    /// A mapping of the raw text of a source to it's location on the file system.
+    var sources: [URL : TextDocument]
+
+    /// The raw arguments provided by SwiftPM.
+    let otherArguments: [String]
+
+    /// Arguments to be sent to SourceKit.
+    var arguments: [String] {
+        return sources.keys.map({ $0.path }) + otherArguments
+    }
+
+    /// Create a false module that is just a collection of source files in a directory. Ideally
+    /// this should not be used since SwiftPM defined modules are preferred.
+    ///
+    /// - Parameter directory: A directory containing a collection of Swift source files.
+    init(_ directory: URL) {
+        name = directory.lastPathComponent
+        let s = WorkspaceSequence(root: directory).lazy
+            .filter({ $0.isFileURL && $0.isFile })
+            .filter({ $0.pathExtension.lowercased() == "swift" }) // Check if file is a Swift source file (e.g., has `.swift` extension)
+            .flatMap(TextDocument.init)
+            .map({ (key: $0.uri, value: $0) })
+        sources = Dictionary(s)
+        otherArguments = []
+    }
+
+    /// Create a module from the definition provided by SwiftPM.
+    ///
+    /// - Parameters:
+    ///   - moduleName: The name of the Swift module.
+    ///   - locations: An array of file paths on the local file system where the sources of the module are found.
+    ///   - arguments: An array of arguments used to compile the module.
+    init(_ moduleName: String, locations: [URL], arguments: [String] = []) {
+        name = moduleName
+        sources = Dictionary(locations
+            .flatMap(TextDocument.init)
+            .map({ (key: $0.uri, value: $0) }))
+        otherArguments = arguments
+    }
+
+    var root: URL {
+        return commonRoot(sources.keys)
+    }
+
+}
+
+extension SwiftModule : Hashable {
+
+    var hashValue: Int {
+        return name.hashValue
+    }
+
+}
+
+extension SwiftModule : Equatable {
+
+    /// Returns a Boolean value indicating whether two values are equal.
+    ///
+    /// Equality is the inverse of inequality. For any values `a` and `b`,
+    /// `a == b` implies that `a != b` is `false`.
+    ///
+    /// - Parameters:
+    ///   - lhs: A value to compare.
+    ///   - rhs: Another value to compare.
+    static func ==(lhs: SwiftModule, rhs: SwiftModule) -> Bool {
+        return lhs.name == rhs.name
+    }
+
+}
+
+extension SwiftModule : YamlConvertable {
+
+    /// - TODO: This really should really be part of `YamlConvertable`. Unfortunately the generic version of this
+    /// causes the compiler to die.
+    /// e.g., this signature
+    /// static func decodeAndFilterFailed<T: YamlConvertable>(_ yaml: Node) -> Decoded<[T]> where T == T.DecodedType {
+    static func decodeAndFilterFailed(_ yaml: Node) -> Decoded<[SwiftModule]> {
+        switch yaml {
+        case .mapping(let o):
+            //        return .typeMismatch(expected: "Array", actual: "")
+            return pure(o.flatMap({ SwiftModule.decode($0.1).value }))
+        default:
+            return .typeMismatch(expected: "Array", actual: "")
+        }
+    }
+
+
+    static func decode(_ yaml: Node) -> Decoded<SwiftModule> {
+        let name = flatReduce(["module-name"], initial: yaml, combine: convertedYAML).flatMap(String.decode)
+        let sources = flatReduce(["sources"], initial: yaml, combine: convertedYAML).flatMap(Array<URL>.decode)
+        let otherArguments = flatReduce(["other-args"], initial: yaml, combine: convertedYAML).flatMap(Array<String>.decode)
+
+        return curry(SwiftModule.init) <^> name <*> sources <*> otherArguments
+    }
+
+}

--- a/Sources/YamlConvertable/Extensions/StandardTypesRyan.swift
+++ b/Sources/YamlConvertable/Extensions/StandardTypesRyan.swift
@@ -1,0 +1,54 @@
+//
+//  StandardTypes.swift
+//  langserver-swift
+//
+//  Created by Ryan Lovelett on 12/18/16.
+//
+//
+
+import Argo
+import Foundation
+import Runes
+import Yams
+
+extension String: YamlConvertable {
+
+    public static func decode(_ yaml: Node) -> Decoded<String> {
+        switch yaml {
+        case .scalar(let s): return pure(s)
+        default: return .typeMismatch(expected: "String", actual: "???")
+        }
+    }
+
+}
+
+extension URL: YamlConvertable {
+
+    public static func decode(_ yaml: Node) -> Decoded<URL> {
+        switch yaml {
+        case .scalar(let s): return pure(URL(fileURLWithPath: s))
+        default: return .typeMismatch(expected: "String", actual: "???")
+        }
+    }
+
+}
+
+public extension Optional where Wrapped: YamlConvertable, Wrapped == Wrapped.DecodedType {
+
+    static func decode(_ yaml: Node) -> Decoded<Wrapped?> {
+        return Wrapped.decode(yaml) >>- { .success(.some($0)) }
+    }
+
+}
+
+public extension Collection where Iterator.Element: YamlConvertable, Iterator.Element == Iterator.Element.DecodedType {
+
+    static func decode(_ yaml: Node) -> Decoded<[Iterator.Element]> {
+        switch yaml {
+        case .mapping(let o): return sequence(o.map({ Iterator.Element.decode($0.1) }))
+        case .sequence(let a): return sequence(a.map(Iterator.Element.decode))
+        default: return .typeMismatch(expected: "Array", actual: "???")
+        }
+    }
+
+}

--- a/Sources/YamlConvertable/Functions/convertedYAML.swift
+++ b/Sources/YamlConvertable/Functions/convertedYAML.swift
@@ -1,0 +1,21 @@
+//
+//  convertedYAML.swift
+//  langserver-swift
+//
+//  Created by Ryan Lovelett on 12/18/16.
+//
+//
+
+import Argo
+import Yams
+
+public func convertedYAML(_ yaml: Node, forKey key: String) -> Decoded<Node> {
+    switch yaml {
+    case .mapping(let o):
+        guard let node = o.first(where: { $0.0 == key }) else {
+            return .missingKey(key)
+        }
+        return pure(node.1)
+    default: return .typeMismatch(expected: "Mapping", actual: "???")
+    }
+}

--- a/Sources/YamlConvertable/Protocols/YamlConvertable.swift
+++ b/Sources/YamlConvertable/Protocols/YamlConvertable.swift
@@ -1,0 +1,18 @@
+//
+//  YamlConvertable.swift
+//  langserver-swift
+//
+//  Created by Ryan Lovelett on 12/18/16.
+//
+//
+
+import Argo
+import Yams
+
+public protocol YamlConvertable {
+
+    associatedtype DecodedType = Self
+
+    static func decode(_ yaml: Node) -> Decoded<DecodedType>
+
+}

--- a/Tests/LanguageServerProtocolTests/Types/DidChangeWatchedFilesParamsTests.swift
+++ b/Tests/LanguageServerProtocolTests/Types/DidChangeWatchedFilesParamsTests.swift
@@ -1,0 +1,24 @@
+//
+//  DidChangeWatchedFilesParamsTests.swift
+//  langserver-swift
+//
+//  Created by Ryan Lovelett on 12/17/16.
+//
+//
+
+@testable import LanguageServerProtocol
+import XCTest
+
+class DidChangeWatchedFilesParamsTests: XCTestCase {
+    
+    func testCreatedFile() {
+        let json = loadJSONFromFixture("workspace-didChangeWatchedFiles-created.json", in: "JSON-RPC/JSON")
+        switch DidChangeWatchedFilesParams.decode(json) {
+        case .success(let params):
+            XCTAssertEqual(params.changes.first?.type, FileChangeType.Created)
+        case .failure(let error):
+            XCTFail(error.description)
+        }
+    }
+    
+}

--- a/Tests/LanguageServerProtocolTests/Types/SwiftModuleTests.swift
+++ b/Tests/LanguageServerProtocolTests/Types/SwiftModuleTests.swift
@@ -1,0 +1,31 @@
+//
+//  SwiftModuleTests.swift
+//  langserver-swift
+//
+//  Created by Ryan Lovelett on 12/23/16.
+//
+//
+
+import Argo
+@testable import LanguageServerProtocol
+@testable import YamlConvertable
+import Yams
+import XCTest
+
+class SwiftModuleTests: XCTestCase {
+
+    func testYamlLoading() {
+        let fixture = getFixture("debug.yaml", in: "ValidLayouts/Simple/.build")!
+        let str = try! String(contentsOf: fixture, encoding: .utf8)
+        let yaml = try! Node(string: str)
+        let foo: Decoded<Node> = flatReduce(["commands"], initial: yaml, combine: convertedYAML)
+        let bar: Decoded<[SwiftModule]> = foo.flatMap(SwiftModule.decodeAndFilterFailed)
+        switch bar {
+        case .success(let modules):
+            XCTAssertEqual(modules.count, 1)
+        case .failure(let error):
+            XCTFail(error.description)
+        }
+    }
+
+}


### PR DESCRIPTION
SourceKit requires proper build arguments to be sent to it in order to properly resolve symbols in the source code. Up until now a naive solution of just using all the Swift (read: files with a `swift` extension) sources as the build arguments was used.

This branch implements two new capabilities. The first, parsing the the SwiftPM manifest files, `debug.yaml` and `release.yaml`. The second, it implements the [`workspace/didChangeWatchedFiles`](https://github.com/Microsoft/language-server-protocol/blob/20cc22ec7abb26c21959a95c5cca1cd8a0fa2d54/protocol.md#workspace_didChangeWatchedFiles) notification from the language server protocol. This is used to watch the `debug.yaml` and `release.yaml` files. If they are changed then new `SwiftModule` is used to parse them and generate new command line arguments to send to SourceKit.

I expect this to be buggy for a little bit. 😟