### PR TITLE
Output flat JSON responses instead of pretty printed ones

### DIFF
--- a/Sources/BaseProtocol/Types/Response.swift
+++ b/Sources/BaseProtocol/Types/Response.swift
@@ -74,7 +74,7 @@ public struct Response {
     public func data(_ headers: [String : String] = [ : ]) -> Data {
         var mutableHeader = headers
 
-        guard let jsonData = try? JSONSerialization.data(withJSONObject: json.JSONObject(), options: .prettyPrinted) else {
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: json.JSONObject()) else {
             return pattern
         }
 

--- a/Tests/BaseProtocolTests/Types/ResponseTests.swift
+++ b/Tests/BaseProtocolTests/Types/ResponseTests.swift
@@ -20,9 +20,9 @@ class ResponseTests: XCTestCase {
     func testSendingErrorMessage() {
         let request = Request.request(id: .number(1), method: "", params: JSON.null)
         let response = Response(to: request, is: PredefinedError.internalError)
-        let message = stringify(response.data([ : ]))
-        XCTAssert(message.contains("Content-Length: 108\r\n"))
-        XCTAssert(message.contains("\"id\" : 1"))
+        let message = stringify(response.data([:]))
+        XCTAssert(message.contains("Content-Length: 75\r\n"))
+        XCTAssert(message.contains("\"id\":1"))
     }
-    
+
 }


### PR DESCRIPTION
Sending pretty printed JSON can mess up with the Client and it will reduce the size of the data sent over the stdout.
