### PR TITLE
Add Makefile to group commands in one place

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,4 @@
 language: objective-c
 osx_image: xcode8.3
 script:
-  - swift --version
-  - swift build --version
-  - swift build -Xswiftc -target -Xswiftc x86_64-apple-macosx10.11
-  - swift test -Xswiftc -target -Xswiftc x86_64-apple-macosx10.11
-  - swift build -Xswiftc -static-stdlib -Xswiftc -target -Xswiftc x86_64-apple-macosx10.11 -c release
+  - make ci

--- a/README.md
+++ b/README.md
@@ -33,21 +33,21 @@ Currently this implementation is used by [Swift for Visual Studio Code](https://
 
 ```
 % cd <path-to-clone>
-% swift build -Xswiftc -target -Xswiftc x86_64-apple-macosx10.11
+% make debug
 ```
 
 or with Xcode
 
 ```
 % cd <path-to-clone>
-% swift package generate-xcodeproj --xcconfig-overrides settings.xcconfig
+% make xcodeproj
 ```
 
 # Test
 
 ```
 % cd <path-to-clone>
-% swift test -Xswiftc -target -Xswiftc x86_64-apple-macosx10.11
+% make test
 ```
 # Debug and Development
 
@@ -62,7 +62,7 @@ In the directory containing the clone of this repository use SwiftPM to generate
 ```
 % git clone https://github.com/RLovelett/langserver-swift.git
 % cd langserver-swift
-% swift package generate-xcodeproj --xcconfig-overrides settings.xcconfig
+% make xcodeproj
 ```
 
 Since the language server client, e.g., VSCode, will actually launch the language server LLDB needs to be told to wait for the application to launch. This can be configured in Xcode after opening the generated project in Xcode. See the screenshot below.
@@ -80,6 +80,12 @@ From a terminal whose current working directory contains the Xcode project previ
 ```
 % xcodebuild -project langserver-swift.xcodeproj -target "LanguageServer" -showBuildSettings | grep "TARGET_BUILD_DIR"
    TARGET_BUILD_DIR = /Users/ryan/Library/Developer/Xcode/DerivedData/langserver-swift-gellhgzzpradfqbgjnbtkvzjqymv/Build/Products/Debug
+```
+
+Or using `make`:
+
+```
+% make print_target_build_dir
 ```
 
 Take note of this value it will be used later.


### PR DESCRIPTION
This adds a `Makefile` to move from "commands to run in README" to "commands in code".

#### Rationale
- help others start on the project without having to manually copy/paste commands from the README.
- have only one place of truth for the commands to invoke for build, tests, release...
- simplify the maintenance of the development/ci commands.

#### Usage
Available commands can be listed using `make help`.
Examples:
- `make debug` build the project in debug
- `make xcodeproj` generate the Xcode project with the correct settings
- `make release` generate a release build with the expected flags