### PR TITLE
Add rules to Makefile for cleaning, installing, and uninstalling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DefaultBuildFlags=-Xswiftc -target -Xswiftc x86_64-apple-macosx10.11
 DebugBuildFlags=$(DefaultBuildFlags)
-ReleaseBuildFlags=$(DefaultBuildFlags) -Xswiftc -static-stdlib -c release
+ReleaseBuildFlags=$(DefaultBuildFlags) -c release
+INSTALL_PATH?=/usr/local
 
 .PHONY: debug
 ## Build the package in debug
@@ -11,6 +12,23 @@ debug:
 ## Build the package in release
 release:
 	swift build $(ReleaseBuildFlags)
+
+.PHONY: clean
+## Clean the package of build information
+clean:
+	rm -rf .build
+
+.PHONY: install
+## Install the release version of the package
+install: release
+	cp -f .build/release/langserver-swift $(INSTALL_PATH)/bin/langserver-swift
+	cp -f .build/x86_64-apple-macosx10.10/release/libSwiftPM.dylib $(INSTALL_PATH)/lib/libSwiftPM.dylib
+
+.PHONY: uninstall
+## Undo the effects of install
+uninstall:
+	rm -r $(INSTALL_PATH)/bin/langserver-swift
+	rm -r $(INSTALL_PATH)/lib/libSwiftPM.dylib
 
 .PHONY: test
 ## Build and run the tests


### PR DESCRIPTION
This commit also removes the release build flag for using a static
stdlib (i.e. `-Xswiftc -static-stdlib`) because the stdlib is embedded
in libSwiftPM.dylib. After installing, having the stdlib in both of
those was causing issues and undefined behavior. I imagine that the
'undefined behavior' wouldn't be too terrible since the stdlib versions
would be the same, but it generated a lot of warning messages while
running the server.