### PR TITLE
Compile as a statically-linked binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DefaultBuildFlags=-Xswiftc -target -Xswiftc x86_64-apple-macosx10.11
 DebugBuildFlags=$(DefaultBuildFlags)
-ReleaseBuildFlags=$(DefaultBuildFlags) -c release
+ReleaseBuildFlags=$(DefaultBuildFlags) -Xswiftc -static-stdlib -c release
 INSTALL_PATH?=/usr/local
 
 .PHONY: debug
@@ -22,13 +22,11 @@ clean:
 ## Install the release version of the package
 install: release
 	cp -f .build/release/langserver-swift $(INSTALL_PATH)/bin/langserver-swift
-	cp -f .build/x86_64-apple-macosx10.10/release/libSwiftPM.dylib $(INSTALL_PATH)/lib/libSwiftPM.dylib
 
 .PHONY: uninstall
 ## Undo the effects of install
 uninstall:
 	rm -r $(INSTALL_PATH)/bin/langserver-swift
-	rm -r $(INSTALL_PATH)/lib/libSwiftPM.dylib
 
 .PHONY: test
 ## Build and run the tests

--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/RLovelett/swift-package-manager.git",
         "state": {
           "branch": null,
-          "revision": "73028ae4302ba0fa8a6862a8fc8ebd2dc205b151",
-          "version": "4.0.0-beta.2"
+          "revision": "38defaa2a2fb39f6b0b01c52d24e5e0bfc0b6d97",
+          "version": "4.0.0-rc.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/thoughtbot/Argo.git", from: "4.1.2"),
         .package(url: "https://github.com/edwardaux/Ogra.git", from: "4.1.2"),
         .package(url: "https://github.com/thoughtbot/Curry.git", from: "3.0.0"),
-        .package(url: "https://github.com/RLovelett/swift-package-manager.git", .exact("4.0.0-beta.2")),
+        .package(url: "https://github.com/RLovelett/swift-package-manager.git", .exact("4.0.0-rc.1")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
This change bumps the [SwiftPM library to the latest in the swift-4.0-branch](https://github.com/RLovelett/swift-package-manager/releases/tag/4.0.0-rc.1). Additionally it compiles SwiftPM as a static library. This re-enables the language server to be statically-linked.

This is a partial revert of the changes made in #32.

@michaelkent94 if you were able to check these changes out to make sure they actually work the way you intended I'd appreciate it.