### PR TITLE
[WIP] Provide Support for Linux

### DIFF
--- a/Fixtures/JSON-RPC/Requests/initialize.txt
+++ b/Fixtures/JSON-RPC/Requests/initialize.txt
@@ -1,1 +1,3 @@
-Content-Length: 185\r\n\r\n{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"initialize\",\"params\":{\"processId\":65017,\"rootPath\":\"/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple\",\"capabilities\":{},\"trace\":\"off\"}}
+Content-Length: 185
+
+{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":65017,"rootPath":"/Users/ryan/Source/langserver-swift/Fixtures/ValidLayouts/Simple","capabilities":{},"trace":"off"}}

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "CSDJournal",
+        "repositoryURL": "https://github.com/felix91gr/Csdjournal.git",
+        "state": {
+          "branch": null,
+          "revision": "2bc89bbb56bd010efc2916e07eb9dddc6fbfb362",
+          "version": "1.2.0"
+        }
+      },
+      {
         "package": "Curry",
         "repositoryURL": "https://github.com/thoughtbot/Curry.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -22,12 +22,14 @@ let package = Package(
         .package(url: "https://github.com/RLovelett/Ogra.git", .branch("master")),
         .package(url: "https://github.com/thoughtbot/Curry.git", from: "4.0.0"),
         .package(url: "https://github.com/RLovelett/swift-package-manager.git", .branch("swift-4.1-branch")),
+        .package(url: "https://github.com/felix91gr/Csdjournal.git", from: "1.0.1"),
     ],
     targets: [
         .target(
             name: "BaseProtocol",
             dependencies: [
                 "Argo",
+                "CSDJournal",
                 "Curry",
                 "Ogra",
             ]
@@ -42,6 +44,7 @@ let package = Package(
             name: "LanguageServerProtocol",
             dependencies: [
                 "BaseProtocol",
+                "CSDJournal",
                 "SourceKitter",
                 "SwiftPM",
             ]
@@ -50,6 +53,7 @@ let package = Package(
             name: "LanguageServer",
             dependencies: [
                 "BaseProtocol",
+                "CSDJournal",
                 "LanguageServerProtocol",
             ]
         ),

--- a/Sources/BaseProtocol/Types/Request.swift
+++ b/Sources/BaseProtocol/Types/Request.swift
@@ -7,6 +7,7 @@
 //
 
 import Argo
+import CSDJournal
 import Curry
 import Foundation
 import Runes
@@ -95,6 +96,11 @@ public enum Request {
         // the method. This member MAY be omitted.
         let dParams: Decoded<JSON> = json["params"] <|> pure(.null)
 
+        csd_journal_print(LOG_DEBUG, #file, String(#line), #function, json.description)
+        csd_journal_print(LOG_DEBUG, #file, String(#line), #function, dMethod.description)
+        csd_journal_print(LOG_DEBUG, #file, String(#line), #function, dId.description)
+        csd_journal_print(LOG_DEBUG, #file, String(#line), #function, dParams.description)
+
         switch (dMethod, dId, dParams) {
         case (.success(let m), .success(let i), .success(let j)):
             self = .request(id: i, method: m, params: j)
@@ -124,6 +130,7 @@ extension Request.Identifier : Argo.Decodable {
         case .string(let s):
             return .success(.string(s))
         default:
+            csd_journal_print(LOG_DEBUG, #file, String(#line), #function, json.description)
             return .typeMismatch(expected: "String or Number", actual: json)
         }
     }

--- a/Sources/LanguageServerProtocol/Types/Server.swift
+++ b/Sources/LanguageServerProtocol/Types/Server.swift
@@ -45,7 +45,7 @@ func findBinDirectory() -> AbsolutePath {
     }
     return AbsolutePath(foundPath).parentDirectory
     #else
-    return AbsolutePath("/usr/bin/swiftc").parentDirectory
+    return AbsolutePath("/home/rlovelett/Source/swift-source/rlovelett-installation/usr/bin/swiftc").parentDirectory
     #endif
 }
 

--- a/Sources/LanguageServerProtocol/Types/Server.swift
+++ b/Sources/LanguageServerProtocol/Types/Server.swift
@@ -35,6 +35,7 @@ private let log = OSLog(subsystem: "me.lovelett.langserver-swift", category: "Wo
 ///
 /// - Returns: The absolute path to the bin directory containing the Swift compiler.
 func findBinDirectory() -> AbsolutePath {
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
     let whichSwiftcArgs = ["xcrun", "--find", "swiftc"]
     // No value in env, so search for `clang`.
     let foundPath = (try? Process.checkNonZeroExit(arguments: whichSwiftcArgs).chomp()) ?? ""
@@ -43,6 +44,9 @@ func findBinDirectory() -> AbsolutePath {
         return AbsolutePath("/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin")
     }
     return AbsolutePath(foundPath).parentDirectory
+    #else
+    return AbsolutePath("/usr/bin/swiftc").parentDirectory
+    #endif
 }
 
 /// A directory on the local filesystem that contains all of the sources of the Swift project.

--- a/Sources/SourceKitter/Types/library_wrapper.swift
+++ b/Sources/SourceKitter/Types/library_wrapper.swift
@@ -153,7 +153,7 @@ internal let linuxFindSwiftInstallationLibPath: String? = {
     }
 
     /// .../bin/swift -> .../lib
-    return swiftPath.deleting(lastPathComponents: 2) + "lib"
+    return swiftPath.deleting(lastPathComponents: 2).appending(pathComponent: "/lib")
 }()
 
 /// Fallback path on Linux if no better option is available.
@@ -198,11 +198,7 @@ private let xcrunFindPath: String? = {
     var end = output.startIndex
     var contentsEnd = output.startIndex
     output.getLineStart(&start, end: &end, contentsEnd: &contentsEnd, for: start..<start)
-#if swift(>=4.0)
     let xcrunFindSwiftPath = String(output[start..<contentsEnd])
-#else
-    let xcrunFindSwiftPath = output[start..<contentsEnd]
-#endif
     guard xcrunFindSwiftPath.hasSuffix("/usr/bin/swift") else {
         return nil
     }

--- a/Tests/BaseProtocolTests/Types/HeaderTests.swift
+++ b/Tests/BaseProtocolTests/Types/HeaderTests.swift
@@ -12,19 +12,31 @@ import XCTest
 class HeaderTests: XCTestCase {
 
     func testHeaderWithNumericContentLength() {
-        let d = loadFixture("shutdown.txt", in: "JSON-RPC/Requests")!
+        guard let d = loadFixture("shutdown.txt", in: "JSON-RPC/Requests") else {
+            XCTFail("loadFixture failed")
+            return
+        }
+        
         let header = Header(d)
         XCTAssertEqual(header.contentLength, 58)
     }
 
     func testHeaderWithoutContentLength() {
-        let d = loadFixture("non-numeric-content-length.txt", in: "JSON-RPC/Requests")!
+        guard let d = loadFixture("non-numeric-content-length.txt", in: "JSON-RPC/Requests") else {
+            XCTFail("loadFixture failed")
+            return
+        }
+        
         let header = Header(d)
         XCTAssertNil(header.contentLength)
     }
 
     func testHeaderWithMultipleFields() {
-        let d = loadFixture("multiple-field-header.txt", in: "JSON-RPC/Requests")!
+        guard let d = loadFixture("multiple-field-header.txt", in: "JSON-RPC/Requests") else {
+            XCTFail("loadFixture failed")
+            return
+        }
+        
         var it = Header(d)
 
         // Content-Length: 271

--- a/Tests/BaseProtocolTests/Types/HeaderTests.swift
+++ b/Tests/BaseProtocolTests/Types/HeaderTests.swift
@@ -47,3 +47,17 @@ class HeaderTests: XCTestCase {
     }
 
 }
+
+#if os(Linux)
+
+extension HeaderTests {
+    static var allTests: [(String, (HeaderTests) -> () throws -> Void)] {
+        return [
+            ("testHeaderWithNumericContentLength", testHeaderWithNumericContentLength),   
+            ("testHeaderWithoutContentLength", testHeaderWithoutContentLength),   
+            ("testHeaderWithMultipleFields", testHeaderWithMultipleFields),   
+        ]
+    }
+}
+
+#endif

--- a/Tests/BaseProtocolTests/Types/RequestIteratorTests.swift
+++ b/Tests/BaseProtocolTests/Types/RequestIteratorTests.swift
@@ -65,3 +65,17 @@ class RequestIteratorTests: XCTestCase {
     }
 
 }
+
+#if os(Linux)
+
+extension RequestIteratorTests {
+    static var allTests: [(String, (RequestIteratorTests) -> () throws -> Void)] {
+        return [
+            ("testIteratingMultipleRequestsAndHeaders", testIteratingMultipleRequestsAndHeaders),   
+            ("testIteratingFullAndPartialRequestsWithoutCrash", testIteratingFullAndPartialRequestsWithoutCrash),   
+            ("testIteratingByAppendingBuffers", testIteratingByAppendingBuffers),   
+        ]
+    }
+}
+
+#endif

--- a/Tests/BaseProtocolTests/Types/RequestIteratorTests.swift
+++ b/Tests/BaseProtocolTests/Types/RequestIteratorTests.swift
@@ -12,7 +12,11 @@ import XCTest
 class RequestIteratorTests: XCTestCase {
 
     func testIteratingMultipleRequestsAndHeaders() {
-        let d = loadFixture("multiple-requests-and-headers.txt", in: "JSON-RPC/Requests")!
+        guard let d = loadFixture("multiple-requests-and-headers.txt", in: "JSON-RPC/Requests") else {
+            XCTFail("loadFixture failed")
+            return
+        }
+
         let c = Array(AnySequence { RequestBuffer(d) })
 
         XCTAssertEqual(c.count, 4)
@@ -20,7 +24,11 @@ class RequestIteratorTests: XCTestCase {
     }
 
     func testIteratingFullAndPartialRequestsWithoutCrash() {
-        let d = loadFixture("partial-request.txt", in: "JSON-RPC/Requests")!
+        guard let d = loadFixture("partial-request.txt", in: "JSON-RPC/Requests") else {
+            XCTFail("loadFixture failed")
+            return
+        }
+
         let it = RequestBuffer(d)
 
         let first = it.next()
@@ -33,9 +41,20 @@ class RequestIteratorTests: XCTestCase {
     }
 
     func testIteratingByAppendingBuffers() {
-        let d1 = loadFixture("partial-request-1.txt", in: "JSON-RPC/Requests")!
-        let d2 = loadFixture("partial-request-2.txt", in: "JSON-RPC/Requests")!
-        let d3 = loadFixture("partial-request-3.txt", in: "JSON-RPC/Requests")!
+        guard let d1 = loadFixture("partial-request-1.txt", in: "JSON-RPC/Requests") else {
+            XCTFail("loadFixture failed")
+            return
+        }
+
+        guard let d2 = loadFixture("partial-request-2.txt", in: "JSON-RPC/Requests") else {
+            XCTFail("loadFixture failed")
+            return
+        }
+
+        guard let d3 = loadFixture("partial-request-3.txt", in: "JSON-RPC/Requests") else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         let it = RequestBuffer(Data())
         // Since no data was sent to start it should have nothing in it

--- a/Tests/BaseProtocolTests/Types/RequestTests.swift
+++ b/Tests/BaseProtocolTests/Types/RequestTests.swift
@@ -153,3 +153,25 @@ class RequestTests: XCTestCase {
     }
 
 }
+
+#if os(Linux)
+
+extension RequestTests {
+    static var allTests: [(String, (RequestTests) -> () throws -> Void)] {
+        return [
+            ("testNotJSONContent", testNotJSONContent),   
+            ("testInvalidRequestJSON", testInvalidRequestJSON),   
+            ("testValidRequest", testValidRequest),
+
+            ("testInvalidHeader", testInvalidHeader),   
+            ("testValidHeaderAndRequest", testValidHeaderAndRequest),   
+            ("testParsingParameters", testParsingParameters),   
+
+            ("testParsingIncorrectParameters", testParsingIncorrectParameters),   
+            ("testShutdownRequest", testShutdownRequest),   
+            ("testTextDocumentDidOpen", testTextDocumentDidOpen),   
+        ]
+    }
+}
+
+#endif

--- a/Tests/BaseProtocolTests/Types/RequestTests.swift
+++ b/Tests/BaseProtocolTests/Types/RequestTests.swift
@@ -45,7 +45,10 @@ class RequestTests: XCTestCase {
     }
 
     func testNotJSONContent() {
-        let message = invalid!
+        guard let message = invalid else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         do {
             _ = try Request(message)
@@ -57,7 +60,10 @@ class RequestTests: XCTestCase {
     }
 
     func testInvalidRequestJSON() {
-        let message = invalidRequest!
+        guard let message = invalidRequest else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         do {
             _ = try Request(message)
@@ -69,7 +75,10 @@ class RequestTests: XCTestCase {
     }
 
     func testValidRequest() {
-        let message = validWithoutHeader!
+        guard let message = validWithoutHeader else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         do {
             _ = try Request(message)
@@ -79,7 +88,10 @@ class RequestTests: XCTestCase {
     }
 
     func testInvalidHeader() {
-        let message = invalidHeader!
+        guard let message = invalidHeader else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         do {
             _ = try Request(message)
@@ -91,7 +103,10 @@ class RequestTests: XCTestCase {
     }
 
     func testValidHeaderAndRequest() {
-        let message = valid!
+        guard let message = valid else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         do {
             let r = try Request(message)
@@ -103,7 +118,10 @@ class RequestTests: XCTestCase {
     }
 
     func testParsingParameters() {
-        let message = valid!
+        guard let message = valid else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         do {
             let r = try Request(message)
@@ -115,7 +133,10 @@ class RequestTests: XCTestCase {
     }
 
     func testParsingIncorrectParameters() {
-        let message = valid2!
+        guard let message = valid2 else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         do {
             let r = try Request(message)
@@ -129,7 +150,10 @@ class RequestTests: XCTestCase {
     }
 
     func testShutdownRequest() {
-        let message = shutdown!
+        guard let message = shutdown else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         do {
             let r = try Request(message)
@@ -141,7 +165,10 @@ class RequestTests: XCTestCase {
     }
 
     func testTextDocumentDidOpen() {
-        let message = textDocumentDidOpen!
+        guard let message = textDocumentDidOpen else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         do {
             let r = try Request(message)

--- a/Tests/BaseProtocolTests/Types/ResponseTests.swift
+++ b/Tests/BaseProtocolTests/Types/ResponseTests.swift
@@ -26,3 +26,15 @@ class ResponseTests: XCTestCase {
     }
 
 }
+
+#if os(Linux)
+
+extension ResponseTests {
+    static var allTests: [(String, (ResponseTests) -> () throws -> Void)] {
+        return [
+            ("testSendingErrorMessage", testSendingErrorMessage),   
+        ]
+    }
+}
+
+#endif

--- a/Tests/LanguageServerProtocolTests/Extensions/URLTests.swift
+++ b/Tests/LanguageServerProtocolTests/Extensions/URLTests.swift
@@ -57,3 +57,16 @@ class URLTests: XCTestCase {
     }
     
 }
+
+#if os(Linux)
+
+extension URLTests {
+    static var allTests: [(String, (URLTests) -> () throws -> Void)] {
+        return [
+            ("testDecodeDirectory", testDecodeDirectory),
+            ("testDecodeFile", testDecodeFile),      
+        ]
+    }
+}
+
+#endif

--- a/Tests/LanguageServerProtocolTests/Functions/ConvertTests.swift
+++ b/Tests/LanguageServerProtocolTests/Functions/ConvertTests.swift
@@ -21,3 +21,15 @@ class ConvertTests: XCTestCase {
     }
 
 }
+
+#if os(Linux)
+
+extension ConvertTests {
+    static var allTests: [(String, (ConvertTests) -> () throws -> Void)] {
+        return [
+            ("testExample", testExample),   
+        ]
+    }
+}
+
+#endif

--- a/Tests/LanguageServerProtocolTests/Types/CompletionItemTests.swift
+++ b/Tests/LanguageServerProtocolTests/Types/CompletionItemTests.swift
@@ -81,3 +81,18 @@ class CompletionItemTests: XCTestCase {
     }
 
 }
+
+#if os(Linux)
+
+extension CompletionItemTests {
+    static var allTests: [(String, (CompletionItemTests) -> () throws -> Void)] {
+        return [
+            ("testParseCompletionItems", testParseCompletionItems),
+            ("testKeywordCompletionItem", testKeywordCompletionItem),    
+            ("testProtocolCompletionItem", testProtocolCompletionItem),
+            ("testConstructorCompletionItem", testConstructorCompletionItem),      
+        ]
+    }
+}
+
+#endif

--- a/Tests/LanguageServerProtocolTests/Types/CursorTests.swift
+++ b/Tests/LanguageServerProtocolTests/Types/CursorTests.swift
@@ -46,3 +46,16 @@ class CursorTests: XCTestCase {
     }
     
 }
+
+#if os(Linux)
+
+extension CursorTests {
+    static var allTests: [(String, (CursorTests) -> () throws -> Void)] {
+        return [
+            ("testSystemSymbol", testSystemSymbol),
+            ("testModuleSymbol", testModuleSymbol),      
+        ]
+    }
+}
+
+#endif

--- a/Tests/LanguageServerProtocolTests/Types/DidChangeWatchedFilesParamsTests.swift
+++ b/Tests/LanguageServerProtocolTests/Types/DidChangeWatchedFilesParamsTests.swift
@@ -22,3 +22,15 @@ class DidChangeWatchedFilesParamsTests: XCTestCase {
     }
     
 }
+
+#if os(Linux)
+
+extension DidChangeWatchedFilesParamsTests {
+    static var allTests: [(String, (DidChangeWatchedFilesParamsTests) -> () throws -> Void)] {
+        return [
+            ("testCreatedFile", testCreatedFile),
+        ]
+    }
+}
+
+#endif

--- a/Tests/LanguageServerProtocolTests/Types/LineCollectionTests.swift
+++ b/Tests/LanguageServerProtocolTests/Types/LineCollectionTests.swift
@@ -79,3 +79,17 @@ class LineCollectionTests: XCTestCase {
     }
 
 }
+
+#if os(Linux)
+
+extension LineCollectionTests {
+    static var allTests: [(String, (LineCollectionTests) -> () throws -> Void)] {
+        return [
+            ("testOffsetCalculation", testOffsetCalculation),
+            ("testPositionCalculation", testPositionCalculation),      
+            ("testSourceWithoutTrailingNewLine", testSourceWithoutTrailingNewLine),      
+        ]
+    }
+}
+
+#endif

--- a/Tests/LanguageServerProtocolTests/Types/SwiftModuleTests.swift
+++ b/Tests/LanguageServerProtocolTests/Types/SwiftModuleTests.swift
@@ -13,3 +13,14 @@ import XCTest
 class SwiftModuleTests: XCTestCase {
 
 }
+
+#if os(Linux)
+
+extension SwiftModuleTests {
+    static var allTests: [(String, (SwiftModuleTests) -> () throws -> Void)] {
+        return [    
+        ]
+    }
+}
+
+#endif

--- a/Tests/LanguageServerProtocolTests/Types/SwiftSourceTests.swift
+++ b/Tests/LanguageServerProtocolTests/Types/SwiftSourceTests.swift
@@ -35,3 +35,16 @@ class SwiftSourceTests: XCTestCase {
     }
 
 }
+
+#if os(Linux)
+
+extension SwiftSourceTests {
+    static var allTests: [(String, (SwiftSourceTests) -> () throws -> Void)] {
+        return [
+            ("testFindDefintion", testFindDefintion),
+            ("testTwo", testTwo),      
+        ]
+    }
+}
+
+#endif

--- a/Tests/LanguageServerProtocolTests/Types/WorkspaceTests.swift
+++ b/Tests/LanguageServerProtocolTests/Types/WorkspaceTests.swift
@@ -37,3 +37,15 @@ class WorkspaceTests: XCTestCase {
     }
 
 }
+
+#if os(Linux)
+
+extension WorkspaceTests {
+    static var allTests: [(String, (WorkspaceTests) -> () throws -> Void)] {
+        return [
+            ("testWorkspace", testWorkspace),
+        ]
+    }
+}
+
+#endif


### PR DESCRIPTION
### Infraestructure
- [x] Update the build tools and CI

### Code

<details><summary>Ogra Error Message</summary><p>

```
/home/rlovelett/Source/langserver-swift/.build/checkouts/Ogra.git-4459770976581387768/Sources/Encodable.swift:95:128: warning: redundant same-type constraint 'Wrapped.Iterator.Element' == 'Wrapped.Element'
extension Optional where Wrapped: Collection & ExpressibleByArrayLiteral, Wrapped.Element: Encodable, Wrapped.Iterator.Element == Wrapped.Element {
                                                                                                                               ^
/home/rlovelett/Source/langserver-swift/.build/checkouts/Ogra.git-4459770976581387768/Sources/Encodable.swift:95:33: note: previous same-type constraint 'Wrapped.Element' == 'Wrapped.Iterator.Element' implied here
extension Optional where Wrapped: Collection & ExpressibleByArrayLiteral, Wrapped.Element: Encodable, Wrapped.Iterator.Element == Wrapped.Element {
                                ^
/home/rlovelett/Source/langserver-swift/.build/checkouts/Ogra.git-4459770976581387768/Sources/Encodable.swift:89:102: warning: redundant conformance constraint 'Self.Element': 'Encodable'
extension Collection where Self: ExpressibleByArrayLiteral, Self.Element: Encodable, Iterator.Element: Encodable {
                                                                                                     ^
/home/rlovelett/Source/langserver-swift/.build/checkouts/Ogra.git-4459770976581387768/Sources/Encodable.swift:89:73: note: conformance constraint 'Self.Element': 'Encodable' written here
extension Collection where Self: ExpressibleByArrayLiteral, Self.Element: Encodable, Iterator.Element: Encodable {
                                                                        ^
/home/rlovelett/Source/langserver-swift/.build/checkouts/Ogra.git-4459770976581387768/Sources/Encodable.swift:36:18: error: cannot convert value of type 'Int' to type 'NSNumber' in coercion
                return .number(self as NSNumber)
                               ^~~~
/home/rlovelett/Source/langserver-swift/.build/checkouts/Ogra.git-4459770976581387768/Sources/Encodable.swift:42:18: error: cannot convert value of type 'Double' to type 'NSNumber' in coercion
                return .number(self as NSNumber)
                               ^~~~
/home/rlovelett/Source/langserver-swift/.build/checkouts/Ogra.git-4459770976581387768/Sources/Encodable.swift:48:18: error: cannot convert value of type 'Float' to type 'NSNumber' in coercion
                return .number(self as NSNumber)
                               ^~~~
/home/rlovelett/Source/langserver-swift/.build/checkouts/Ogra.git-4459770976581387768/Sources/Encodable.swift:54:18: error: cannot convert value of type 'UInt' to type 'NSNumber' in coercion
                return .number(self as NSNumber)
                               ^~~~
/home/rlovelett/Source/langserver-swift/.build/checkouts/Ogra.git-4459770976581387768/Sources/Encodable.swift:109:29: error: cannot convert value of type 'Int' to type 'NSNumber' in coercion
        return .number(self.rawValue as NSNumber)
                       ~~~~~^~~~~~~~
/home/rlovelett/Source/langserver-swift/.build/checkouts/Ogra.git-4459770976581387768/Sources/Encodable.swift:115:29: error: cannot convert value of type 'Double' to type 'NSNumber' in coercion
        return .number(self.rawValue as NSNumber)
                       ~~~~~^~~~~~~~
/home/rlovelett/Source/langserver-swift/.build/checkouts/Ogra.git-4459770976581387768/Sources/Encodable.swift:121:29: error: cannot convert value of type 'Float' to type 'NSNumber' in coercion
        return .number(self.rawValue as NSNumber)
                       ~~~~~^~~~~~~~
/home/rlovelett/Source/langserver-swift/.build/checkouts/Ogra.git-4459770976581387768/Sources/Encodable.swift:127:29: error: cannot convert value of type 'UInt' to type 'NSNumber' in coercion
        return .number(self.rawValue as NSNumber)
                       ~~~~~^~~~~~~~
error: terminated(1): /usr/bin/swift-build-tool -f /home/rlovelett/Source/langserver-swift/.build/debug.yaml main output:
```
</p></details>

- [x] Fix Ogra (Fixed in #38)
- [x] Update source code to Swift 4.1 (Fixed in #38)
- [x] Update SwiftPM to Swift 4.1 (Fixed in #38)
- [ ] Cross-platform logging
- [ ] Get [PR that fixes SR-5773](https://github.com/apple/swift-corelibs-libdispatch/pull/356) merged into `corelibs-libdispatch`
- [ ] Ensure all tests are passing

### Documentation
- [ ] Update the `README`