### PR TITLE
Extended test coverage to Linux

### DIFF
--- a/Tests/BaseProtocolTests/Types/HeaderTests.swift
+++ b/Tests/BaseProtocolTests/Types/HeaderTests.swift
@@ -47,3 +47,17 @@ class HeaderTests: XCTestCase {
     }
 
 }
+
+#if os(Linux)
+
+extension HeaderTests {
+    static var allTests: [(String, (HeaderTests) -> () throws -> Void)] {
+        return [
+            ("testHeaderWithNumericContentLength", testHeaderWithNumericContentLength),   
+            ("testHeaderWithoutContentLength", testHeaderWithoutContentLength),   
+            ("testHeaderWithMultipleFields", testHeaderWithMultipleFields),   
+        ]
+    }
+}
+
+#endif

--- a/Tests/BaseProtocolTests/Types/RequestIteratorTests.swift
+++ b/Tests/BaseProtocolTests/Types/RequestIteratorTests.swift
@@ -65,3 +65,17 @@ class RequestIteratorTests: XCTestCase {
     }
 
 }
+
+#if os(Linux)
+
+extension RequestIteratorTests {
+    static var allTests: [(String, (RequestIteratorTests) -> () throws -> Void)] {
+        return [
+            ("testIteratingMultipleRequestsAndHeaders", testIteratingMultipleRequestsAndHeaders),   
+            ("testIteratingFullAndPartialRequestsWithoutCrash", testIteratingFullAndPartialRequestsWithoutCrash),   
+            ("testIteratingByAppendingBuffers", testIteratingByAppendingBuffers),   
+        ]
+    }
+}
+
+#endif

--- a/Tests/BaseProtocolTests/Types/RequestTests.swift
+++ b/Tests/BaseProtocolTests/Types/RequestTests.swift
@@ -153,3 +153,25 @@ class RequestTests: XCTestCase {
     }
 
 }
+
+#if os(Linux)
+
+extension RequestTests {
+    static var allTests: [(String, (RequestTests) -> () throws -> Void)] {
+        return [
+            ("testNotJSONContent", testNotJSONContent),   
+            ("testInvalidRequestJSON", testInvalidRequestJSON),   
+            ("testValidRequest", testValidRequest),
+
+            ("testInvalidHeader", testInvalidHeader),   
+            ("testValidHeaderAndRequest", testValidHeaderAndRequest),   
+            ("testParsingParameters", testParsingParameters),   
+
+            ("testParsingIncorrectParameters", testParsingIncorrectParameters),   
+            ("testShutdownRequest", testShutdownRequest),   
+            ("testTextDocumentDidOpen", testTextDocumentDidOpen),   
+        ]
+    }
+}
+
+#endif

--- a/Tests/BaseProtocolTests/Types/ResponseTests.swift
+++ b/Tests/BaseProtocolTests/Types/ResponseTests.swift
@@ -26,3 +26,15 @@ class ResponseTests: XCTestCase {
     }
 
 }
+
+#if os(Linux)
+
+extension ResponseTests {
+    static var allTests: [(String, (ResponseTests) -> () throws -> Void)] {
+        return [
+            ("testSendingErrorMessage", testSendingErrorMessage),   
+        ]
+    }
+}
+
+#endif

--- a/Tests/LanguageServerProtocolTests/Extensions/URLTests.swift
+++ b/Tests/LanguageServerProtocolTests/Extensions/URLTests.swift
@@ -57,3 +57,16 @@ class URLTests: XCTestCase {
     }
     
 }
+
+#if os(Linux)
+
+extension URLTests {
+    static var allTests: [(String, (URLTests) -> () throws -> Void)] {
+        return [
+            ("testDecodeDirectory", testDecodeDirectory),
+            ("testDecodeFile", testDecodeFile),      
+        ]
+    }
+}
+
+#endif

--- a/Tests/LanguageServerProtocolTests/Functions/ConvertTests.swift
+++ b/Tests/LanguageServerProtocolTests/Functions/ConvertTests.swift
@@ -21,3 +21,15 @@ class ConvertTests: XCTestCase {
     }
 
 }
+
+#if os(Linux)
+
+extension ConvertTests {
+    static var allTests: [(String, (ConvertTests) -> () throws -> Void)] {
+        return [
+            ("testExample", testExample),   
+        ]
+    }
+}
+
+#endif

--- a/Tests/LanguageServerProtocolTests/Types/CompletionItemTests.swift
+++ b/Tests/LanguageServerProtocolTests/Types/CompletionItemTests.swift
@@ -79,3 +79,18 @@ class CompletionItemTests: XCTestCase {
     }
 
 }
+
+#if os(Linux)
+
+extension CompletionItemTests {
+    static var allTests: [(String, (CompletionItemTests) -> () throws -> Void)] {
+        return [
+            ("testParseCompletionItems", testParseCompletionItems),
+            ("testKeywordCompletionItem", testKeywordCompletionItem),    
+            ("testProtocolCompletionItem", testProtocolCompletionItem),
+            ("testConstructorCompletionItem", testConstructorCompletionItem),      
+        ]
+    }
+}
+
+#endif

--- a/Tests/LanguageServerProtocolTests/Types/CursorTests.swift
+++ b/Tests/LanguageServerProtocolTests/Types/CursorTests.swift
@@ -46,3 +46,16 @@ class CursorTests: XCTestCase {
     }
     
 }
+
+#if os(Linux)
+
+extension CursorTests {
+    static var allTests: [(String, (CursorTests) -> () throws -> Void)] {
+        return [
+            ("testSystemSymbol", testSystemSymbol),
+            ("testModuleSymbol", testModuleSymbol),      
+        ]
+    }
+}
+
+#endif

--- a/Tests/LanguageServerProtocolTests/Types/DidChangeWatchedFilesParamsTests.swift
+++ b/Tests/LanguageServerProtocolTests/Types/DidChangeWatchedFilesParamsTests.swift
@@ -22,3 +22,15 @@ class DidChangeWatchedFilesParamsTests: XCTestCase {
     }
     
 }
+
+#if os(Linux)
+
+extension DidChangeWatchedFilesParamsTests {
+    static var allTests: [(String, (DidChangeWatchedFilesParamsTests) -> () throws -> Void)] {
+        return [
+            ("testCreatedFile", testCreatedFile),
+        ]
+    }
+}
+
+#endif

--- a/Tests/LanguageServerProtocolTests/Types/LineCollectionTests.swift
+++ b/Tests/LanguageServerProtocolTests/Types/LineCollectionTests.swift
@@ -79,3 +79,17 @@ class LineCollectionTests: XCTestCase {
     }
 
 }
+
+#if os(Linux)
+
+extension LineCollectionTests {
+    static var allTests: [(String, (LineCollectionTests) -> () throws -> Void)] {
+        return [
+            ("testOffsetCalculation", testOffsetCalculation),
+            ("testPositionCalculation", testPositionCalculation),      
+            ("testSourceWithoutTrailingNewLine", testSourceWithoutTrailingNewLine),      
+        ]
+    }
+}
+
+#endif

--- a/Tests/LanguageServerProtocolTests/Types/SwiftModuleTests.swift
+++ b/Tests/LanguageServerProtocolTests/Types/SwiftModuleTests.swift
@@ -13,3 +13,14 @@ import XCTest
 class SwiftModuleTests: XCTestCase {
 
 }
+
+#if os(Linux)
+
+extension SwiftModuleTests {
+    static var allTests: [(String, (SwiftModuleTests) -> () throws -> Void)] {
+        return [    
+        ]
+    }
+}
+
+#endif

--- a/Tests/LanguageServerProtocolTests/Types/SwiftSourceTests.swift
+++ b/Tests/LanguageServerProtocolTests/Types/SwiftSourceTests.swift
@@ -35,3 +35,16 @@ class SwiftSourceTests: XCTestCase {
     }
 
 }
+
+#if os(Linux)
+
+extension SwiftSourceTests {
+    static var allTests: [(String, (SwiftSourceTests) -> () throws -> Void)] {
+        return [
+            ("testFindDefintion", testFindDefintion),
+            ("testTwo", testTwo),      
+        ]
+    }
+}
+
+#endif

--- a/Tests/LanguageServerProtocolTests/Types/WorkspaceTests.swift
+++ b/Tests/LanguageServerProtocolTests/Types/WorkspaceTests.swift
@@ -37,3 +37,15 @@ class WorkspaceTests: XCTestCase {
     }
 
 }
+
+#if os(Linux)
+
+extension WorkspaceTests {
+    static var allTests: [(String, (WorkspaceTests) -> () throws -> Void)] {
+        return [
+            ("testWorkspace", testWorkspace),
+        ]
+    }
+}
+
+#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import BaseProtocolTests
+@testable import LanguageServerProtocolTests
+
+XCTMain([
+
+	/*
+		Base Protocol Tests
+	*/
+
+	/// Types
+    // FIXME: Crashes the test suite
+    // testCase(HeaderTests.allTests), 
+
+    // FIXME: Crashes the test suite
+    // testCase(RequestIteratorTests.allTests),
+
+    // FIXME: Crashes the test suite
+    // testCase(RequestTests.allTests),
+    
+    testCase(ResponseTests.allTests),
+
+	/*
+		Language Server Protocol Tests
+	*/
+
+	// Extensions
+    testCase(URLTests.allTests),
+    
+    // Functions
+    testCase(ConvertTests.allTests),
+
+    // Types
+    testCase(CompletionItemTests.allTests),
+    testCase(CursorTests.allTests),
+    testCase(DidChangeWatchedFilesParamsTests.allTests),
+    testCase(LineCollectionTests.allTests),
+    testCase(SwiftModuleTests.allTests),
+    testCase(SwiftSourceTests.allTests),
+    testCase(WorkspaceTests.allTests),
+])


### PR DESCRIPTION
#### Test coverage:
* Put Linux-only commands at the end of the test files so that `LinuxMain.swift` can pick up the test functions.
* Filled `LinuxMain.swift` with calls to the test functions. There's one line per test file.
#### Missing coverage:
* There are 3 FIXMEs in the `LinuxMain.swift` file. Those are related to test files that make the test suite crash.
#### Other
* Renamed a test file (`RequestBufferTests.swift` to `RequestIteratorTests.swift`) because its test name was different. Now they are the same.

