### PR TITLE
Added guard statements and XCTFail declarations. Full Linux coverage.

### DIFF
--- a/Tests/BaseProtocolTests/Types/HeaderTests.swift
+++ b/Tests/BaseProtocolTests/Types/HeaderTests.swift
@@ -12,19 +12,31 @@ import XCTest
 class HeaderTests: XCTestCase {
 
     func testHeaderWithNumericContentLength() {
-        let d = loadFixture("shutdown.txt", in: "JSON-RPC/Requests")!
+        guard let d = loadFixture("shutdown.txt", in: "JSON-RPC/Requests") else {
+            XCTFail("loadFixture failed")
+            return
+        }
+        
         let header = Header(d)
         XCTAssertEqual(header.contentLength, 58)
     }
 
     func testHeaderWithoutContentLength() {
-        let d = loadFixture("non-numeric-content-length.txt", in: "JSON-RPC/Requests")!
+        guard let d = loadFixture("non-numeric-content-length.txt", in: "JSON-RPC/Requests") else {
+            XCTFail("loadFixture failed")
+            return
+        }
+        
         let header = Header(d)
         XCTAssertNil(header.contentLength)
     }
 
     func testHeaderWithMultipleFields() {
-        let d = loadFixture("multiple-field-header.txt", in: "JSON-RPC/Requests")!
+        guard let d = loadFixture("multiple-field-header.txt", in: "JSON-RPC/Requests") else {
+            XCTFail("loadFixture failed")
+            return
+        }
+        
         var it = Header(d)
 
         // Content-Length: 271

--- a/Tests/BaseProtocolTests/Types/RequestIteratorTests.swift
+++ b/Tests/BaseProtocolTests/Types/RequestIteratorTests.swift
@@ -12,7 +12,11 @@ import XCTest
 class RequestIteratorTests: XCTestCase {
 
     func testIteratingMultipleRequestsAndHeaders() {
-        let d = loadFixture("multiple-requests-and-headers.txt", in: "JSON-RPC/Requests")!
+        guard let d = loadFixture("multiple-requests-and-headers.txt", in: "JSON-RPC/Requests") else {
+            XCTFail("loadFixture failed")
+            return
+        }
+
         let c = Array(AnySequence { RequestBuffer(d) })
 
         XCTAssertEqual(c.count, 4)
@@ -20,7 +24,11 @@ class RequestIteratorTests: XCTestCase {
     }
 
     func testIteratingFullAndPartialRequestsWithoutCrash() {
-        let d = loadFixture("partial-request.txt", in: "JSON-RPC/Requests")!
+        guard let d = loadFixture("partial-request.txt", in: "JSON-RPC/Requests") else {
+            XCTFail("loadFixture failed")
+            return
+        }
+
         let it = RequestBuffer(d)
 
         let first = it.next()
@@ -33,9 +41,20 @@ class RequestIteratorTests: XCTestCase {
     }
 
     func testIteratingByAppendingBuffers() {
-        let d1 = loadFixture("partial-request-1.txt", in: "JSON-RPC/Requests")!
-        let d2 = loadFixture("partial-request-2.txt", in: "JSON-RPC/Requests")!
-        let d3 = loadFixture("partial-request-3.txt", in: "JSON-RPC/Requests")!
+        guard let d1 = loadFixture("partial-request-1.txt", in: "JSON-RPC/Requests") else {
+            XCTFail("loadFixture failed")
+            return
+        }
+
+        guard let d2 = loadFixture("partial-request-2.txt", in: "JSON-RPC/Requests") else {
+            XCTFail("loadFixture failed")
+            return
+        }
+
+        guard let d3 = loadFixture("partial-request-3.txt", in: "JSON-RPC/Requests") else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         let it = RequestBuffer(Data())
         // Since no data was sent to start it should have nothing in it

--- a/Tests/BaseProtocolTests/Types/RequestTests.swift
+++ b/Tests/BaseProtocolTests/Types/RequestTests.swift
@@ -45,7 +45,10 @@ class RequestTests: XCTestCase {
     }
 
     func testNotJSONContent() {
-        let message = invalid!
+        guard let message = invalid else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         do {
             _ = try Request(message)
@@ -57,7 +60,10 @@ class RequestTests: XCTestCase {
     }
 
     func testInvalidRequestJSON() {
-        let message = invalidRequest!
+        guard let message = invalidRequest else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         do {
             _ = try Request(message)
@@ -69,7 +75,10 @@ class RequestTests: XCTestCase {
     }
 
     func testValidRequest() {
-        let message = validWithoutHeader!
+        guard let message = validWithoutHeader else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         do {
             _ = try Request(message)
@@ -79,7 +88,10 @@ class RequestTests: XCTestCase {
     }
 
     func testInvalidHeader() {
-        let message = invalidHeader!
+        guard let message = invalidHeader else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         do {
             _ = try Request(message)
@@ -91,7 +103,10 @@ class RequestTests: XCTestCase {
     }
 
     func testValidHeaderAndRequest() {
-        let message = valid!
+        guard let message = valid else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         do {
             let r = try Request(message)
@@ -103,7 +118,10 @@ class RequestTests: XCTestCase {
     }
 
     func testParsingParameters() {
-        let message = valid!
+        guard let message = valid else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         do {
             let r = try Request(message)
@@ -115,7 +133,10 @@ class RequestTests: XCTestCase {
     }
 
     func testParsingIncorrectParameters() {
-        let message = valid2!
+        guard let message = valid2 else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         do {
             let r = try Request(message)
@@ -129,7 +150,10 @@ class RequestTests: XCTestCase {
     }
 
     func testShutdownRequest() {
-        let message = shutdown!
+        guard let message = shutdown else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         do {
             let r = try Request(message)
@@ -141,7 +165,10 @@ class RequestTests: XCTestCase {
     }
 
     func testTextDocumentDidOpen() {
-        let message = textDocumentDidOpen!
+        guard let message = textDocumentDidOpen else {
+            XCTFail("loadFixture failed")
+            return
+        }
 
         do {
             let r = try Request(message)

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -9,15 +9,11 @@ XCTMain([
 	*/
 
 	/// Types
-    // FIXME: Crashes the test suite
-    // testCase(HeaderTests.allTests), 
+    // FIXME: these 3 fail because of BaseProtocolTests/Resources/Fixtures.swift @loadFixture
+    testCase(HeaderTests.allTests), 
+    testCase(RequestIteratorTests.allTests),
+    testCase(RequestTests.allTests),
 
-    // FIXME: Crashes the test suite
-    // testCase(RequestIteratorTests.allTests),
-
-    // FIXME: Crashes the test suite
-    // testCase(RequestTests.allTests),
-    
     testCase(ResponseTests.allTests),
 
 	/*


### PR DESCRIPTION
Added guard statements to replace forced unwraps that would otherwise crash Linux when running certain tests. Now that those tests are safe, I've enabled them on Linux. With this commit, 100% of the tests run on Linux.

The next step will be to make them all pass :)