### PR TITLE
Update Travis to Xcode 9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ---
 language: objective-c
-osx_image: xcode9.3beta
+osx_image: xcode9.3
 script:
   - make ci


### PR DESCRIPTION
This is a housekeeping change to update Travis to use Xcode 9.3 which should use the released Swift 4.1 toolchain.