### PR TITLE
FileHandle#waitForDataInBackgroundAndNotify is not implemented on Linux

### DIFF
--- a/Sources/BaseProtocol/Types/RequestBuffer.swift
+++ b/Sources/BaseProtocol/Types/RequestBuffer.swift
@@ -35,6 +35,12 @@ public class RequestBuffer {
         #endif
     }
 
+    public func append(_ data: DispatchData) {
+        data.withUnsafeBytes { [count = data.count] in
+            buffer.append($0, count: count)
+        }
+    }
+
 }
 
 extension RequestBuffer : IteratorProtocol {

--- a/Sources/LanguageServer/main.swift
+++ b/Sources/LanguageServer/main.swift
@@ -7,43 +7,58 @@ private let header: [String : String] = [
     "Content-Type": "application/vscode-jsonrpc; charset=utf8"
 ]
 
-let main = OperationQueue.main
-let stdin = FileHandle.standardInput
+let readQueue = DispatchQueue(label: "me.lovelett.language-server.dispatchio", qos: .utility, attributes: [], autoreleaseFrequency: .workItem, target: nil)
 var requests = RequestBuffer()
-stdin.waitForDataInBackgroundAndNotify()
 
-// When new data is available
-var dataAvailable : NSObjectProtocol!
-dataAvailable = NotificationCenter.default.addObserver(forName: .NSFileHandleDataAvailable, object: stdin, queue: main) { (notification) -> Void in
-    let buffer = stdin.availableData
+let channel = DispatchIO(type: .stream, fileDescriptor: FileHandle.standardInput.fileDescriptor, queue: readQueue) { (error) in
+    // If the error parameter contains a non zero value, control was relinquished because there was an error creating
+    // the channel; otherwise, this value should be 0.
+    // See: https://developer.apple.com/documentation/dispatch/dispatchio/1388976-init
+    exit(error)
+}
 
-    guard !buffer.isEmpty else {
-        return stdin.waitForDataInBackgroundAndNotify()
-    }
+// The desire is to trigger the handler block as soon as there is any data in the channel.
+channel.setLimit(lowWater: 1)
 
-    requests.append(buffer)
-
-    for requestBuffer in requests {
-        do {
-            let request = try Request(requestBuffer)
-            let response = handle(request)
-            /// If the request id is null then it is a notification and not a request
-            switch request {
-            case .request(_, _, _):
-                let toSend = response.data(header)
-                FileHandle.standardOutput.write(toSend)
-            default: ()
+channel.read(offset: 0, length: Int.max, queue: readQueue) { (done, dispatchData, error) in
+    switch (done, dispatchData, error) {
+    case (true, _, 1...):
+        // If an unrecoverable error occurs on the channel’s file descriptor, the `done` parameter is set to `true` and
+        // an appropriate error value is reported in the handler’s error parameter.
+        fatalError("An unrecoverable error occurred on stdin. \(error)")
+    case (true, let data?, 0) where data.isEmpty:
+        // If the handler is submitted with the `done` parameter set to `true`, an empty `data` object, and an `error`
+        // code of `0`, it means that the channel reached the end of the file.
+        channel.close()
+    case (_, let data?, 0) where !data.isEmpty:
+        requests.append(data)
+        for requestBuffer in requests {
+            do {
+                let request = try Request(requestBuffer)
+                let response = handle(request)
+                /// If the request id is null then it is a notification and not a request
+                switch request {
+                case .request(_, _, _):
+                    let toSend = response.data(header)
+                    // TODO: Writing to stdout should really be done on the main queue
+                    FileHandle.standardOutput.write(toSend)
+                default: ()
+                }
+            } catch let error as PredefinedError {
+                fatalError(error.description)
+            } catch {
+                fatalError("TODO: Better error handeling. \(error)")
             }
-        } catch let error as PredefinedError {
-            fatalError(error.description)
-        } catch {
-            fatalError("TODO: Better error handeling. \(error)")
         }
+        if (done) {
+            // If the `done` parameter is set to `true`, it means the read operation is complete and the handler will
+            // not be submitted again.
+            channel.close()
+        }
+    default:
+        fatalError("This is an unexpected case.")
     }
-
-    return stdin.waitForDataInBackgroundAndNotify()
 }
 
 // Launch the task
 RunLoop.main.run()
-//while RunLoop.main.run(mode: .defaultRunLoopMode, before: .distantFuture) {}


### PR DESCRIPTION
The original run loop which is watching standard input for incoming text does not work on Linux. The reason is that the function is marked `NSUnimplemented()`. [I did attempt a patch to swift-corelibs-foundation to implement `waitForDataInBackgroundAndNotify`](https://github.com/apple/swift-corelibs-foundation/pull/1427).

Unfortunately, there are other issues with the run loop as implemented e.g., https://github.com/RLovelett/vscode-swift/issues/36.

I felt the best solution was just switch to using DispatchIO to watch standard input on a well defined run loop.

Fixes issue #41