### PR TITLE
Update the CompletionItem type to adopt SnippetString API

### DIFF
--- a/Sources/LanguageServerProtocol/Functions/Convert.swift
+++ b/Sources/LanguageServerProtocol/Functions/Convert.swift
@@ -19,12 +19,11 @@ fileprivate let regex = try! NSRegularExpression(pattern: "<#T##([^#]+)#(?:#[^#]
 ///
 /// ```
 /// let str = "fatalError(<#T##message: String##String#>)"
-/// convert(str).value! // "fatalError({{1:message: String}})"
+/// convert(str).value! // "fatalError(${1:message: String})"
 /// ```
 ///
 /// - Parameter sourceKit: A `String` possibly containing an SourceKit style snippet.
-/// - Returns: A `String` where any SourceKit style snippets have been converted to TextMate
-/// snippets.
+/// - Returns: A `String` where any SourceKit style snippets have been converted to TextMate snippets.
 func convert(_ sourceKit: String) -> Decoded<String> {
     var result = ""
     var lastRange = sourceKit.startIndex..<sourceKit.startIndex
@@ -39,7 +38,7 @@ func convert(_ sourceKit: String) -> Decoded<String> {
         }
         cursorIndex += 1
         result += sourceKit[lastRange.upperBound..<matchRange.lowerBound]
-        result += "{{\(cursorIndex):\(group)}}"
+        result += "${\(cursorIndex):\(group)}"
         lastRange = matchRange
     }
     result += sourceKit[lastRange.upperBound...]

--- a/Sources/LanguageServerProtocol/Types/CompletionItem.swift
+++ b/Sources/LanguageServerProtocol/Types/CompletionItem.swift
@@ -39,7 +39,18 @@ public struct CompletionItem {
 
     /// A string that should be inserted a document when selecting this completion. When `falsy` the
     /// label is used.
+    ///
+    /// The `insertText` is subject to interpretation by the client side. Some tools might not take the string
+    /// literally. For example VS Code when code complete is requested in this example `con<cursor position>` and a
+    /// completion item with an `insertText` of `console` is provided it will only insert `sole`. Therefore it is
+    /// recommended to use `textEdit` instead since it avoids additional client side interpretation.
+    ///
+    /// - Warning: This property is deprecated. Use `textEdit` instead.
     var insertText: String?
+
+    /// The format of the insert text. The format applies to both the `insertText` property and the `newText` property
+    /// of a provided `textEdit`.
+    var insertTextFormat: InsertTextFormat? = .snippet
 
     /// An edit which is applied to a document when selecting this completion. When an edit is
     /// provided the value of insertText is ignored.
@@ -90,6 +101,10 @@ extension CompletionItem : Ogra.Encodable {
 
         if let insertText = self.insertText {
             obj["insertText"] = JSON.string(insertText)
+        }
+
+        if let insertTextFormat = self.insertTextFormat {
+            obj["insertTextFormat"] = JSON.number(NSNumber(value: insertTextFormat.rawValue))
         }
 
         if let textEdit = self.textEdit {

--- a/Sources/LanguageServerProtocol/Types/InsertTextFormat.swift
+++ b/Sources/LanguageServerProtocol/Types/InsertTextFormat.swift
@@ -1,0 +1,19 @@
+//
+//  InsertTextFormat.swift
+//  LanguageServerProtocol
+//
+//  Created by Ryan Lovelett on 5/28/18.
+//
+
+/// Defines whether the insert text in a completion item should be interpreted as plain text or a snippet.
+public enum InsertTextFormat: Int {
+    /// The primary text to be inserted is treated as a plain string.
+    case plainText = 1
+
+    /// The primary text to be inserted is treated as a snippet.
+    ///
+    /// A snippet can define tab stops and placeholders with `$1`, `$2` and `${3:foo}`. `$0` defines the final tab stop,
+    /// it defaults to the end of the snippet. Placeholders with equal identifiers are linked, that is typing in one
+    /// will update others too.
+    case snippet = 2
+}

--- a/Tests/LanguageServerProtocolTests/Functions/ConvertTests.swift
+++ b/Tests/LanguageServerProtocolTests/Functions/ConvertTests.swift
@@ -13,11 +13,11 @@ class ConvertTests: XCTestCase {
 
     func testExample() {
         XCTAssertEqual(convert("<#Ryan>").value, "<#Ryan>")
-        XCTAssertEqual(convert("fatalError(<#T##message: String##String#>)").value, "fatalError({{1:message: String}})")
-        XCTAssertEqual(convert("x: <#T##Int#>, y: <#T##String#>)").value, "x: {{1:Int}}, y: {{2:String}})")
-        XCTAssertEqual(convert("debugPrint(<#T##items: Any...##Any#>, to: &<#T##Target#>)").value, "debugPrint({{1:items: Any...}}, to: &{{2:Target}})")
-        XCTAssertEqual(convert("isKnownUniquelyReferenced(&<#T##object: T?##T?#>)").value, "isKnownUniquelyReferenced(&{{1:object: T?}})")
-        XCTAssertEqual(convert("getVaList(<#T##args: [CVarArg]##[CVarArg]#>)").value, "getVaList({{1:args: [CVarArg]}})")
+        XCTAssertEqual(convert("fatalError(<#T##message: String##String#>)").value, "fatalError(${1:message: String})")
+        XCTAssertEqual(convert("x: <#T##Int#>, y: <#T##String#>)").value, "x: ${1:Int}, y: ${2:String})")
+        XCTAssertEqual(convert("debugPrint(<#T##items: Any...##Any#>, to: &<#T##Target#>)").value, "debugPrint(${1:items: Any...}, to: &${2:Target})")
+        XCTAssertEqual(convert("isKnownUniquelyReferenced(&<#T##object: T?##T?#>)").value, "isKnownUniquelyReferenced(&${1:object: T?})")
+        XCTAssertEqual(convert("getVaList(<#T##args: [CVarArg]##[CVarArg]#>)").value, "getVaList(${1:args: [CVarArg]})")
     }
 
 }

--- a/Tests/LanguageServerProtocolTests/Types/CompletionItemTests.swift
+++ b/Tests/LanguageServerProtocolTests/Types/CompletionItemTests.swift
@@ -72,6 +72,8 @@ class CompletionItemTests: XCTestCase {
             XCTAssertEqual(item.kind, CompletionItemKind.Constructor)
             XCTAssertEqual(item.label, "(x: Int, y: String)")
             XCTAssertEqual(item.detail, "Test.Bar (x: Int, y: String)")
+            XCTAssertEqual(item.insertText, "x: ${1:Int}, y: ${2:String})")
+            XCTAssertEqual(item.insertTextFormat, .snippet)
             XCTAssertNil(item.documentation)
         case .failure(let e):
             XCTFail(e.description)


### PR DESCRIPTION
The `CompletionItem` gets a new property, `insertTextFormat`, which is of type `InsertTextFormat`.

Also, as part of the change the format of a snippet whent from `{{1:Type}}` to `${1:Type}`.

Fixes #45