### PR TITLE
Fix some cross-module definition calls

### DIFF
--- a/Sources/LanguageServerProtocol/Types/Server.swift
+++ b/Sources/LanguageServerProtocol/Types/Server.swift
@@ -177,10 +177,17 @@ public class Server {
         // SourceKit may send back JSON that is an empty object. This is _not_ an error condition.
         // So we have to seperate SourceKit throwing an error from SourceKit sending back a
         // "malformed" Cursor structure.
-        let result = SourceKit.CursorInfo(source: source.text, source: at.textDocument.uri, offset: offset, args: module.arguments)
+
+        let intraModuleResult = SourceKit.CursorInfo(source: source.text, source: at.textDocument.uri, offset: offset, args: module.arguments)
             .request()
             .flatMap(Cursor.decode)
-        return result.value
+
+        // TODO This doesn't work in all cases https://github.com/RLovelett/langserver-swift/issues/52
+        let interModuleResult = SourceKit.CursorInfo(source: source.text, source: at.textDocument.uri, offset: offset, args: module.arguments + modules.flatMap { $0.sources.keys.map { $0.path } })
+            .request()
+            .flatMap(Cursor.decode)
+
+        return intraModuleResult.value ?? interModuleResult.value
     }
 
     /// Find the definition of a symbol and provide the `Location` of same definition.


### PR DESCRIPTION
Before:

![2018-06-01 01 17 07](https://user-images.githubusercontent.com/1387653/40829923-c885dd46-6539-11e8-9ca1-dc2f3f942003.gif)

After:

![2018-06-01 01 18 02](https://user-images.githubusercontent.com/1387653/40829926-ca0959fe-6539-11e8-8429-f181222dc669.gif)

Admittedly, this doesn't work in all cases (e.g. the call to `SourceKit.CodeComplete` in https://github.com/RLovelett/langserver-swift/issues/52), which is pretty ironic because that's the case that I tried to fix 😒 

If anyone has any tips for figuring out what arguments to pass to `swift` to get it to resolve these properly, that would be very helpful, because so far my best strategy is Try Random Combinations And Hope It Works ™️ 