### PR TITLE
Show types and render docs in markdown

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "AEXML",
-        "repositoryURL": "https://github.com/tadija/AEXML.git",
-        "state": {
-          "branch": "master",
-          "revision": "6eea665515d079c338690147082a8084a36484b0",
-          "version": null
-        }
-      },
-      {
         "package": "Argo",
         "repositoryURL": "https://github.com/RLovelett/Argo.git",
         "state": {
@@ -62,6 +53,15 @@
           "branch": "swift-4.1-branch",
           "revision": "717de5e5a534e50fe176a510d7502b63b4901678",
           "version": null
+        }
+      },
+      {
+        "package": "SWXMLHash",
+        "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
+        "state": {
+          "branch": null,
+          "revision": "2211b35c2e0e8b08493f86ba52b26e530cabb751",
+          "version": "4.7.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/RLovelett/Ogra.git", .branch("master")),
         .package(url: "https://github.com/thoughtbot/Curry.git", from: "4.0.0"),
         .package(url: "https://github.com/RLovelett/swift-package-manager.git", .branch("swift-4.1-branch")),
-        .package(url: "https://github.com/tadija/AEXML.git", from: "4.3.0")
+        .package(url: "https://github.com/drmohundro/SWXMLHash.git", from: "4.0.0"),
     ],
     targets: [
         .target(
@@ -45,7 +45,7 @@ let package = Package(
                 "BaseProtocol",
                 "SourceKitter",
                 "SwiftPM",
-                "AEXML",
+                "SWXMLHash",
             ]
         ),
         .target(

--- a/Sources/LanguageServerProtocol/Types/Server.swift
+++ b/Sources/LanguageServerProtocol/Types/Server.swift
@@ -204,6 +204,14 @@ public class Server {
             return []
         }
     }
+    
+    // Gets the string contents of an XML element, recursively
+    //
+    // deepString(doc: "<tag1><tag2>some text</tag2> <tag2>here</tag2></tag1>")
+    // => "some text here"
+    private func deepString(element: SWXMLHashXMLElement) -> String {
+        return element.recursiveText
+    }
 
     /// Find information about a symbol.
     ///
@@ -218,7 +226,8 @@ public class Server {
 
         let contents: [MarkedString] = [
             MarkedString(language: "swift", value: c.typename),
-            (SWXMLHash.parse(c.fullyAnnotatedDeclaration).element?.recursiveText)
+            (SWXMLHash.parse(c.fullyAnnotatedDeclaration).element)
+                .map { deepString(element: $0) }
                 .map { MarkedString(language: "swift", value: $0) },
             c.documentationAsXML
                 .map { SWXMLHash.parse($0).children[0].filterChildren { element, _ in element.name == "CommentParts" }.element }?

--- a/Sources/LanguageServerProtocol/Types/Server.swift
+++ b/Sources/LanguageServerProtocol/Types/Server.swift
@@ -24,7 +24,7 @@ import class PackageModel.ResolvedTarget
 import SourceKitter
 import struct Utility.BuildFlags
 import class Workspace.Workspace
-import AEXML
+import SWXMLHash
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 private let log = OSLog(subsystem: "me.lovelett.langserver-swift", category: "Workspace")
@@ -205,17 +205,6 @@ public class Server {
         }
     }
 
-    // Gets the string contents of an AEXMLElement, recursively, with spaces
-    // separating the individual element contents.
-    //
-    // deepString(doc: "<tag1><tag2>some text</tag2><tag2>here</tag2></tag1>")
-    // => "some text here"
-    private func deepString(doc: AEXMLElement) -> String {
-        return doc.children.count == 0 ?
-            doc.string :
-            doc.children.map(deepString).joined(separator: " ")
-    }
-
     /// Find information about a symbol.
     ///
     /// - Parameter at: A `TextDocument` and a position inside that document.
@@ -228,14 +217,14 @@ public class Server {
         }
 
         let contents: [MarkedString] = [
-            c.annotatedDeclaration,
-            c.fullyAnnotatedDeclaration,
+            MarkedString(language: "swift", value: c.typename),
+            (SWXMLHash.parse(c.fullyAnnotatedDeclaration).element?.recursiveText)
+                .map { MarkedString(language: "swift", value: $0) },
             c.documentationAsXML
+                .map { SWXMLHash.parse($0).children[0].filterChildren { element, _ in element.name == "CommentParts" }.element }?
+                .map { MarkedString(language: "markdown", value: $0.recursiveText) }
         ]
             .compactMap { $0 }
-            .compactMap { try? AEXMLDocument(xml: $0) }
-            .map { deepString(doc: $0.root) }
-            .map { MarkedString(language: "swift", value: $0) }
 
         switch c.defined {
         case let .local(filepath, symbolOffset, symbolLength):


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/1387653/40840061-f27b9080-6559-11e8-8471-8751a33b89f0.png)

After:

![image](https://user-images.githubusercontent.com/1387653/40840146-4f77c07e-655a-11e8-95ad-698f212acc2a.png)

I switched from AEXML to [SWXMLHash](https://github.com/drmohundro/SWXMLHash) because AEXML doesn't properly expose the text nodes within XML via its API:

![image](https://user-images.githubusercontent.com/1387653/40840170-689f4946-655a-11e8-8477-afa8fd74e845.png)

But SWXMLHash does:

![image](https://user-images.githubusercontent.com/1387653/40840172-6e8c7a40-655a-11e8-9ab4-c13c55c37dcf.png)

The rendering of the docs could be better with some massaging of the XML structure, but I was unable to figure out how to do properly.