### PR TITLE
Fallback to parent directory for unknown Swift Modules

### DIFF
--- a/Sources/LanguageServerProtocol/Types/Server.swift
+++ b/Sources/LanguageServerProtocol/Types/Server.swift
@@ -123,7 +123,12 @@ public class Server {
             guard let source = module.sources[uri] else { continue }
             return (module, source)
         }
-        throw WorkspaceError.notFound(uri)
+        let singleFileModule = SwiftModule(uri.deletingLastPathComponent())
+        if let source = singleFileModule.sources[uri] {
+            return (singleFileModule, source)
+        } else {
+            throw WorkspaceError.notFound(uri)
+        }
     }
 
     // MARK: - Language Server Protocol methods
@@ -204,7 +209,7 @@ public class Server {
             return []
         }
     }
-    
+
     // Gets the string contents of an XML element, recursively
     //
     // deepString(doc: "<tag1><tag2>some text</tag2> <tag2>here</tag2></tag1>")


### PR DESCRIPTION
We already had a brief chat on gitter on this. 

If no Swift Module could be found for the current file, we create a temporary module for the parent folder. This would import all Swift files within the same directory, which would be a reasonable default for non SwiftPM projects.

Although I am not sure regarding performance as the temporary module will scan the parent directory for every request again. Alternatively we could create a new Swift Module only containing the requested file.

Related issues: #35 and #37